### PR TITLE
Bugfix - enum parsing fixes and default values

### DIFF
--- a/src/main/java/net/sandrohc/jikan/Jikan.java
+++ b/src/main/java/net/sandrohc/jikan/Jikan.java
@@ -66,6 +66,7 @@ public class Jikan {
 
 		this.objectMapper = new ObjectMapper()
 				.registerModule(new JavaTimeModule())
+				.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
 				.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 	}
 

--- a/src/main/java/net/sandrohc/jikan/model/enums/AgeRating.java
+++ b/src/main/java/net/sandrohc/jikan/model/enums/AgeRating.java
@@ -10,6 +10,11 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum AgeRating {
+
+	@JsonProperty("NONE")
+	@JsonAlias("None")
+	NONE,
+
 	@JsonProperty("G")
 	@JsonAlias("G - All Ages")
 	G,

--- a/src/main/java/net/sandrohc/jikan/model/enums/AgeRating.java
+++ b/src/main/java/net/sandrohc/jikan/model/enums/AgeRating.java
@@ -7,10 +7,12 @@
 package net.sandrohc.jikan.model.enums;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum AgeRating {
 
+	@JsonEnumDefaultValue
 	@JsonProperty("NONE")
 	@JsonAlias("None")
 	NONE,

--- a/src/main/java/net/sandrohc/jikan/model/enums/AgeRating.java
+++ b/src/main/java/net/sandrohc/jikan/model/enums/AgeRating.java
@@ -30,7 +30,10 @@ public enum AgeRating {
 	R17,
 
 	@JsonProperty("R+")
-	@JsonAlias("R+ - Mild Nudity (may also contain violence & profanity)")
+	@JsonAlias({
+			"R+ - Mild Nudity",
+			"R+ - Mild Nudity (may also contain violence & profanity)"
+	})
 	R,
 
 	@JsonProperty("Rx")

--- a/src/main/java/net/sandrohc/jikan/model/enums/AnimeStatus.java
+++ b/src/main/java/net/sandrohc/jikan/model/enums/AnimeStatus.java
@@ -7,6 +7,7 @@
 package net.sandrohc.jikan.model.enums;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum AnimeStatus {
@@ -22,6 +23,15 @@ public enum AnimeStatus {
 	UPCOMING,
 
 	@JsonProperty("to_be_aired")
-	@JsonAlias("tba")
+	@JsonAlias({
+			"tba",
+			"to be aired",
+			"not aired yet)"
+	})
 	TO_BE_AIRED,
+
+	@JsonEnumDefaultValue
+	@JsonProperty("Unknown")
+	@JsonAlias("Unknown")
+	UNKONWN
 }

--- a/src/main/java/net/sandrohc/jikan/model/enums/AnimeStatus.java
+++ b/src/main/java/net/sandrohc/jikan/model/enums/AnimeStatus.java
@@ -33,5 +33,5 @@ public enum AnimeStatus {
 	@JsonEnumDefaultValue
 	@JsonProperty("Unknown")
 	@JsonAlias("Unknown")
-	UNKONWN
+	UNKNOWN
 }

--- a/src/main/java/net/sandrohc/jikan/model/enums/AnimeStatus.java
+++ b/src/main/java/net/sandrohc/jikan/model/enums/AnimeStatus.java
@@ -26,7 +26,7 @@ public enum AnimeStatus {
 	@JsonAlias({
 			"tba",
 			"to be aired",
-			"not aired yet)"
+			"Not yet aired"
 	})
 	TO_BE_AIRED,
 

--- a/src/main/java/net/sandrohc/jikan/model/enums/AnimeType.java
+++ b/src/main/java/net/sandrohc/jikan/model/enums/AnimeType.java
@@ -7,6 +7,7 @@
 package net.sandrohc.jikan.model.enums;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum AnimeType {
@@ -17,6 +18,6 @@ public enum AnimeType {
 	@JsonProperty("Movie")   MOVIE,
 	@JsonProperty("Special") SPECIAL,
 	@JsonProperty("Music")   MUSIC,
-
+	@JsonEnumDefaultValue
 	@JsonAlias("-") UNKNOWN,
 }

--- a/src/main/java/net/sandrohc/jikan/model/enums/Day.java
+++ b/src/main/java/net/sandrohc/jikan/model/enums/Day.java
@@ -6,6 +6,7 @@
 
 package net.sandrohc.jikan.model.enums;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum Day {
@@ -17,5 +18,6 @@ public enum Day {
 	@JsonProperty("saturday")  SATURDAY,
 	@JsonProperty("sunday")    SUNDAY,
 	@JsonProperty("other")     OTHER,
+	@JsonEnumDefaultValue
 	@JsonProperty("unknown")   UNKNOWN,
 }

--- a/src/main/java/net/sandrohc/jikan/model/enums/MangaStatus.java
+++ b/src/main/java/net/sandrohc/jikan/model/enums/MangaStatus.java
@@ -7,6 +7,7 @@
 package net.sandrohc.jikan.model.enums;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum MangaStatus {
@@ -20,4 +21,9 @@ public enum MangaStatus {
 	@JsonProperty("To be published")
 	@JsonAlias({ "TBP", "Upcoming" })
 	TO_BE_PUBLISHED,
+
+	@JsonEnumDefaultValue
+	@JsonProperty("Unknown")
+	@JsonAlias("Unknown")
+	UNKNOWN
 }

--- a/src/main/java/net/sandrohc/jikan/model/enums/MangaType.java
+++ b/src/main/java/net/sandrohc/jikan/model/enums/MangaType.java
@@ -7,6 +7,7 @@
 package net.sandrohc.jikan.model.enums;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum MangaType {
@@ -17,6 +18,6 @@ public enum MangaType {
 	@JsonProperty("Doujin")   DOUJIN,
 	@JsonProperty("Manhwa")   MANWHA, // Korean comics
 	@JsonProperty("Manhua")   MANUHA, // Chinese comics
-
+	@JsonEnumDefaultValue
 	@JsonAlias("-") UNKNOWN,
 }

--- a/src/main/java/net/sandrohc/jikan/query/search/AnimeSearchQuery.java
+++ b/src/main/java/net/sandrohc/jikan/query/search/AnimeSearchQuery.java
@@ -27,12 +27,29 @@ public class AnimeSearchQuery extends AdvancedSearchQuery<AnimeSearchQuery, Anim
 
 	@SuppressWarnings("unchecked")
 	public AnimeSearchQuery genres(AnimeGenre... genres) {
-		// TODO: check if we need to include the 'gender_exclude' in the request
 		Set<Integer> genreList = (Set<Integer>) queryParams.computeIfAbsent("genre", key -> new TreeSet<>());
 
 		for (AnimeGenre genre : genres)
 			genreList.add(genre.ordinal());
 
+		return this;
+	}
+
+	/**
+	 * To exclude the genre you added in your request.
+	 * @return anime search query
+	 */
+	public AnimeSearchQuery excludeGivenGenres() {
+		queryParams.putIfAbsent("genre_exclude", 0);
+		return this;
+	}
+
+	/**
+	 * To include the genre you added in your request.
+	 * @return anime search query
+	 */
+	public AnimeSearchQuery includeGivenGenres() {
+		queryParams.putIfAbsent("genre_exclude", 1);
 		return this;
 	}
 

--- a/src/main/java/net/sandrohc/jikan/query/search/MangaSearchQuery.java
+++ b/src/main/java/net/sandrohc/jikan/query/search/MangaSearchQuery.java
@@ -28,12 +28,29 @@ public class MangaSearchQuery extends AdvancedSearchQuery<MangaSearchQuery, Mang
 
 	@SuppressWarnings("unchecked")
 	public MangaSearchQuery genres(MangaGenre... genres) {
-		// TODO: check if we need to include the 'gender_exclude' in the request
 		Set<Integer> genreList = (Set<Integer>) queryParams.computeIfAbsent("genre", key -> new TreeSet<>());
 
 		for (MangaGenre genre : genres)
 			genreList.add(genre.ordinal());
 
+		return this;
+	}
+
+	/**
+	 * To exclude the genre you added in your request.
+	 * @return manga search query
+	 */
+	public MangaSearchQuery excludeGivenGenres() {
+		queryParams.putIfAbsent("genre_exclude", 0);
+		return this;
+	}
+
+	/**
+	 * To include the genre you added in your request.
+	 * @return manga search query
+	 */
+	public MangaSearchQuery includeGivenGenres() {
+		queryParams.putIfAbsent("genre_exclude", 1);
 		return this;
 	}
 

--- a/src/test/java/net/sandrohc/jikan/test/RequestAnimeTest.java
+++ b/src/test/java/net/sandrohc/jikan/test/RequestAnimeTest.java
@@ -159,6 +159,142 @@ public class RequestAnimeTest extends RequestTest {
 	}
 
 	@Test
+	void fetchAnimeWithUnknownAgeRating() {
+		// https://api.jikan.moe/v3/anime/11757
+		String response = "{" +
+				"  \"mal_id\": 1," +
+				"  \"url\": \"https://example.com/url\"," +
+				"  \"image_url\": \"https://example.com/image_url\"," +
+				"  \"trailer_url\": \"https://example.com/trailer_url\"," +
+				"  \"title\": \"TITLE\"," +
+				"  \"title_english\": \"TITLE ENGLISH\"," +
+				"  \"title_japanese\": \"TITLE 日本語\"," +
+				"  \"title_synonyms\": [ \"TITLE_SYNONYM\" ]," +
+				"  \"type\": \"TV\"," +
+				"  \"source\": \"SOURCE\"," +
+				"  \"episodes\": 10," +
+				"  \"status\": \"Finished Airing\"," +
+				"  \"airing\": false," +
+				"  \"aired\": {" +
+				"    \"from\": \"2010-01-01T00:00:00+00:00\"," +
+				"    \"to\": \"2010-12-01T00:00:00+00:00\"" +
+				"  }," +
+				"  \"duration\": \"DURATION\"," +
+				"  \"rating\": \"Invalid age rating\"," + // unknown age rating
+				"  \"score\": 10.00," +
+				"  \"scored_by\": 20," +
+				"  \"rank\": 30," +
+				"  \"popularity\": 40," +
+				"  \"members\": 50," +
+				"  \"favorites\": 60," +
+				"  \"synopsis\": \"SYNOPSIS\"," +
+				"  \"background\": \"BACKGROUND\"," +
+				"  \"premiered\": \"Summer 2012\"," +
+				"  \"broadcast\": \"Sundays at 00:00 (JST)\"," +
+				"  \"related\": {" +
+				"    \"Other\": [" +
+				"      { \"mal_id\": 10000, \"type\": \"anime\", \"name\": \"RELATED_OTHER\", \"url\": \"https://example.com/related_other\" }" +
+				"    ]," +
+				"    \"Sequel\": [" +
+				"      { \"mal_id\": 11000, \"type\": \"anime\", \"name\": \"RELATED_SEQUEL\", \"url\": \"https://example.com/related_sequel\" }" +
+				"    ]" +
+				"  }," +
+				"  \"producers\": [" +
+				"    { \"mal_id\": 1000, \"type\": \"anime\", \"name\": \"PRODUCER\", \"url\": \"https://example.com/producer\" }" +
+				"  ]," +
+				"  \"licensors\": [" +
+				"    { \"mal_id\": 2000, \"type\": \"anime\", \"name\": \"LICENSOR\", \"url\": \"https://example.com/licensor\" }" +
+				"  ]," +
+				"  \"studios\": [" +
+				"    { \"mal_id\": 3000, \"type\": \"anime\", \"name\": \"STUDIO\", \"url\": \"https://example.com/studio\" }" +
+				"  ]," +
+				"  \"genres\": [" +
+				"    { \"mal_id\": 1, \"type\": \"anime\", \"name\": \"Action\", \"url\": \"https://myanimelist.net/anime/genre/1/Action\" }," +
+				"    { \"mal_id\": 2, \"type\": \"anime\", \"name\": \"Adventure\", \"url\": \"https://myanimelist.net/anime/genre/2/Adventure\" }" +
+				"  ]," +
+				"  \"opening_themes\": [ \"OPENING THEME\" ]," +
+				"  \"ending_themes\":  [ \"ENDING THEME\" ]" +
+				"}";
+
+		mock(mockServer, "/anime/1", response);
+
+		AnimeQuery query = jikan.query().anime().get(1);
+		assertNotNull(query);
+		assertNotNull(query.toString());
+		Anime anime = query.execute().block();
+		assertNotNull(anime);
+		assertEquals(AgeRating.NONE, anime.rating);
+	}
+
+	@Test
+	void fetchAnimeWithUnknownType() {
+		// https://api.jikan.moe/v3/anime/11757
+		String response = "{" +
+				"  \"mal_id\": 1," +
+				"  \"url\": \"https://example.com/url\"," +
+				"  \"image_url\": \"https://example.com/image_url\"," +
+				"  \"trailer_url\": \"https://example.com/trailer_url\"," +
+				"  \"title\": \"TITLE\"," +
+				"  \"title_english\": \"TITLE ENGLISH\"," +
+				"  \"title_japanese\": \"TITLE 日本語\"," +
+				"  \"title_synonyms\": [ \"TITLE_SYNONYM\" ]," +
+				"  \"type\": \"INVALID TYPE\"," +
+				"  \"source\": \"SOURCE\"," +
+				"  \"episodes\": 10," +
+				"  \"status\": \"Finished Airing\"," +
+				"  \"airing\": false," +
+				"  \"aired\": {" +
+				"    \"from\": \"2010-01-01T00:00:00+00:00\"," +
+				"    \"to\": \"2010-12-01T00:00:00+00:00\"" +
+				"  }," +
+				"  \"duration\": \"DURATION\"," +
+				"  \"rating\": \"Invalid age rating\"," + // unknown age rating
+				"  \"score\": 10.00," +
+				"  \"scored_by\": 20," +
+				"  \"rank\": 30," +
+				"  \"popularity\": 40," +
+				"  \"members\": 50," +
+				"  \"favorites\": 60," +
+				"  \"synopsis\": \"SYNOPSIS\"," +
+				"  \"background\": \"BACKGROUND\"," +
+				"  \"premiered\": \"Summer 2012\"," +
+				"  \"broadcast\": \"Sundays at 00:00 (JST)\"," +
+				"  \"related\": {" +
+				"    \"Other\": [" +
+				"      { \"mal_id\": 10000, \"type\": \"anime\", \"name\": \"RELATED_OTHER\", \"url\": \"https://example.com/related_other\" }" +
+				"    ]," +
+				"    \"Sequel\": [" +
+				"      { \"mal_id\": 11000, \"type\": \"anime\", \"name\": \"RELATED_SEQUEL\", \"url\": \"https://example.com/related_sequel\" }" +
+				"    ]" +
+				"  }," +
+				"  \"producers\": [" +
+				"    { \"mal_id\": 1000, \"type\": \"anime\", \"name\": \"PRODUCER\", \"url\": \"https://example.com/producer\" }" +
+				"  ]," +
+				"  \"licensors\": [" +
+				"    { \"mal_id\": 2000, \"type\": \"anime\", \"name\": \"LICENSOR\", \"url\": \"https://example.com/licensor\" }" +
+				"  ]," +
+				"  \"studios\": [" +
+				"    { \"mal_id\": 3000, \"type\": \"anime\", \"name\": \"STUDIO\", \"url\": \"https://example.com/studio\" }" +
+				"  ]," +
+				"  \"genres\": [" +
+				"    { \"mal_id\": 1, \"type\": \"anime\", \"name\": \"Action\", \"url\": \"https://myanimelist.net/anime/genre/1/Action\" }," +
+				"    { \"mal_id\": 2, \"type\": \"anime\", \"name\": \"Adventure\", \"url\": \"https://myanimelist.net/anime/genre/2/Adventure\" }" +
+				"  ]," +
+				"  \"opening_themes\": [ \"OPENING THEME\" ]," +
+				"  \"ending_themes\":  [ \"ENDING THEME\" ]" +
+				"}";
+
+		mock(mockServer, "/anime/1", response);
+
+		AnimeQuery query = jikan.query().anime().get(1);
+		assertNotNull(query);
+		assertNotNull(query.toString());
+		Anime anime = query.execute().block();
+		assertNotNull(anime);
+		assertEquals(AnimeType.UNKNOWN, anime.type);
+	}
+
+	@Test
 	void fetchCharactersAndStaff() {
 		// https://api.jikan.moe/v3/anime/11757/characters_staff
 		String response = "{\n" +


### PR DESCRIPTION
One example for an anime that fails to load: https://myanimelist.net/anime/42517/Ookami-san_wa_Taberaretai (age rating: 'R+ - Mild Nudity')

I noticed that json parsing also fails for: https://myanimelist.net/anime/40074/Gibiate (age rating: 'None'), so I added it as well.

**EDIT:**

I have added some default values for Enums where it made sense since I think this kind of issue can pop-up again - also noticed that other Jikan wrappers use Strings for the age rating instead of enums - but I like your approach more.

"None" for the age rating is not meant to be only a fallback solution, it is actually used by MAL itself, see: https://myanimelist.net/anime/40074/Gibiate I am not a 100% sure, but I'd think that an anime like that is not "G - all ages".

**EDIT 2:**

I noticed another problem: `AnimeStatus` was not working correctly for 'not yet aired'. I added this enum alias and a default value 'Unknown'.  (See e.g.: https://myanimelist.net/anime/39617/Yakusoku_no_Neverland_2nd_Season)